### PR TITLE
Bump mdbook dependency to latest v0.4.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,9 +832,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mdbook"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d948b64449003363127ed6c6139f03273982c3fe97da4cb3dee933e38ce38f"
+checksum = "aeb86d199d0c1e8d41f3a9e9b0ba8639d6951a10043129159809ac9c18e3ce05"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -1508,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/badboy/mdbook-mermaid"
 edition = "2018"
 
 [dependencies]
-mdbook = "0.4.5"
+mdbook = "0.4.9"
 pulldown-cmark = "0.7.0"
 pulldown-cmark-to-cmark = "4.0.2"
 env_logger = "0.7.1"


### PR DESCRIPTION
I think this upgrade is needed to fix a compatibility problem noticed in https://github.com/rust-lang/wg-async-foundations/issues/218  which is using the latest mdbook and mdbook-mermaid in CI (v0.4.9 and v0.8.1 respectively, at the time of this writing)

The error seen is:

    Unable to parse the input
    Error: -04 09:00:12 [ERROR] (mdbook::utils): Error: The "mermaid" preprocessor exited unsuccessfully with exit code: 1 status

This error is strangely not reproducible on some machines, but if I add a bit of debugging, I can get this error from mdbook-mermaid:

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("missing field `__non_exhaustive`", line: 1, column: 760)', /devel/mdbook/src/preprocess/cmd.rs:49:42

What I think is happening is that mdbook recently removed a private `__non_exhaustive` field, but one that wasn't set to `#[serde(skip)]`.  This was done in https://github.com/rust-lang/mdBook/pull/1557 which was part of the most recent mdbook v0.4.9 release.

Yet the latest mdbook-mermaid is using mdbook v0.4.6 as a dependency, which expects to deserialize a `__non_exhausive` field.  Hence the above deserializtion error.

