### PR TITLE
Use mdbook v0.4.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,25 +221,12 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -296,15 +283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
 ]
 
 [[package]]
@@ -376,15 +354,15 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "mdbook"
-version = "0.4.18"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74612ae81a3e5ee509854049dfa4c7975ae033c06f5fc4735c7dfbe60ee2a39d"
+checksum = "23f3e133c6d515528745ffd3b9f0c7d975ae039f0b6abb099f2168daa2afb4f9"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
  "clap_complete",
- "env_logger 0.7.1",
+ "env_logger",
  "handlebars",
  "lazy_static",
  "log",
@@ -393,7 +371,6 @@ dependencies = [
  "pulldown-cmark",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "shlex",
  "tempfile",
@@ -407,7 +384,7 @@ version = "0.11.2"
 dependencies = [
  "assert_cmd",
  "clap",
- "env_logger 0.9.0",
+ "env_logger",
  "log",
  "mdbook",
  "pretty_assertions",
@@ -576,12 +553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +613,9 @@ name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/badboy/mdbook-mermaid"
 edition = "2018"
 
 [dependencies]
-mdbook = { version = "0.4.10", default-features = false }
+mdbook = { version = "0.4.21", default-features = false }
 pulldown-cmark = { version = "0.9.0", default-features = false }
 env_logger = "0.9.0"
 log = "0.4.11"


### PR DESCRIPTION
On rust 1.64.0 mdbook v0.4.18 fails to compile:

       Compiling mdbook v0.4.18
    error[E0597]: `local_ctx` does not live long enough
       --> /Users/erichodel/.cargo/registry/src/github.com-1ecc6299db9ec823/mdbook-0.4.18/src/renderer/html_handlebars/helpers/navigation.rs:154:25
        |
    154 |             t.render(r, &local_ctx, &mut local_rc, out)
        |                         ^^^^^^^^^^ borrowed value does not live long enough
    155 |         })?;
        |         -
        |         |
        |         `local_ctx` dropped here while still borrowed
        |         borrow might be used here, when `local_rc` is dropped and runs the destructor for type `handlebars::RenderContext<'_, '_>`
        |
        = note: values in a scope are dropped in the opposite order they are defined

    For more information about this error, try `rustc --explain E0597`.
    error: could not compile `mdbook` due to previous error
    warning: build failed, waiting for other jobs to finish...