### PR TITLE
Handle CR-LF in mermaid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ fn add_mermaid(content: &str) -> Result<String> {
         }
 
         // We're in the code block. The text is what we want.
+        // Code blocks can come in multiple text events.
         if let Event::Text(_) = e {
             if start_new_code_span {
                 code_span = span;
@@ -84,7 +85,6 @@ fn add_mermaid(content: &str) -> Result<String> {
             } else {
                 code_span = code_span.start..span.end;
             }
-            println!("{:?}", e);
             
             continue;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ fn add_mermaid(content: &str) -> Result<String> {
             } else {
                 code_span = code_span.start..span.end;
             }
-            
+
             continue;
         }
 
@@ -291,9 +291,9 @@ Text
     fn crlf_line_endings() {
         let _ = env_logger::try_init();
         let content = "# Chapter\r\n\r\n````mermaid\r\n\r\ngraph TD\r\nA --> B\r\n````";
-        let expected = "# Chapter\r\n\r\n\n<pre class=\"mermaid\">\ngraph TD\nA --&gt; B\n</pre>\n\n";
+        let expected =
+            "# Chapter\r\n\r\n\n<pre class=\"mermaid\">\ngraph TD\nA --&gt; B\n</pre>\n\n";
 
         assert_eq!(expected, add_mermaid(content).unwrap());
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ fn add_mermaid(content: &str) -> Result<String> {
     opts.insert(Options::ENABLE_TASKLISTS);
 
     let mut code_span = 0..0;
+    let mut start_new_code_span = true;
 
     let mut mermaid_blocks = vec![];
 
@@ -77,7 +78,14 @@ fn add_mermaid(content: &str) -> Result<String> {
 
         // We're in the code block. The text is what we want.
         if let Event::Text(_) = e {
-            code_span = span;
+            if start_new_code_span {
+                code_span = span;
+                start_new_code_span = false;
+            } else {
+                code_span = code_span.start..span.end;
+            }
+            println!("{:?}", e);
+            
             continue;
         }
 
@@ -90,8 +98,10 @@ fn add_mermaid(content: &str) -> Result<String> {
 
             let mermaid_content = &content[code_span.clone()];
             let mermaid_content = escape_html(mermaid_content);
+            let mermaid_content = mermaid_content.replace("\r\n", "\n");
             let mermaid_code = format!("<pre class=\"mermaid\">{}</pre>\n\n", mermaid_content);
             mermaid_blocks.push((span, mermaid_code));
+            start_new_code_span = true;
         }
     }
 
@@ -276,4 +286,14 @@ Text
 
         assert_eq!(expected, add_mermaid(content).unwrap());
     }
+
+    #[test]
+    fn crlf_line_endings() {
+        let _ = env_logger::try_init();
+        let content = "# Chapter\r\n\r\n````mermaid\r\n\r\ngraph TD\r\nA --> B\r\n````";
+        let expected = "# Chapter\r\n\r\n\n<pre class=\"mermaid\">\ngraph TD\nA --&gt; B\n</pre>\n\n";
+
+        assert_eq!(expected, add_mermaid(content).unwrap());
+    }
+
 }


### PR DESCRIPTION
mermaid blocks containing CR LF are returned line by line from the parser instead 
of as a complete code chunk for LF only.
We need to expand the span for each chunk we get.
After the closing ticks we replace the remaining \r\n with \n to have a consistent line ending 
in the mermaid code at least.

fixes #26 