### PR TITLE
feat: add expand to modal feature for diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ into this:
 in your book.
 (Graph provided by [Mermaid Live Editor](https://mermaidjs.github.io/mermaid-live-editor/#/view/eyJjb2RlIjoiZ3JhcGggVEQ7XG4gICAgQS0tPkI7XG4gICAgQS0tPkM7XG4gICAgQi0tPkQ7XG4gICAgQy0tPkQ7IiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifX0))
 
+Each diagram includes an expand icon in the upper-right corner (visible on hover) that opens the diagram in a
+full-viewport modal for better readability. The modal can be closed by clicking the X button, clicking the backdrop, or
+pressing Escape.
+
 ## Installation
 
 ### From source
@@ -67,11 +71,12 @@ command = "mdbook-mermaid"
 
 [output.html]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-css = ["mermaid-modal.css"]
 ```
 
 It will skip any unnecessary changes and detect if `mdbook-mermaid` was already configured.
 
-Additionally it copies the files `mermaid.min.js` and  `mermaid-init.js` into your book's directory.
+Additionally it copies the files `mermaid.min.js`, `mermaid-init.js`, and `mermaid-modal.css` into your book's directory.
 You find these files in the [`src/bin/assets`](src/bin/assets) directory.
 You can modify `mermaid-init.js` to configure Mermaid, see the [Mermaid documentation] for all options.
 

--- a/src/bin/assets/mermaid-init.js
+++ b/src/bin/assets/mermaid-init.js
@@ -5,9 +5,10 @@
 (() => {
     const darkThemes = ['ayu', 'navy', 'coal'];
     const mermaidModalId = 'mermaid-diagram-modal';
-    const maximizeIcon = `
-        <svg viewBox="0 0 448 512" aria-hidden="true" focusable="false">
-            <path fill="currentColor" d="M168 32L24 32C10.7 32 0 42.7 0 56L0 200c0 9.7 5.8 18.5 14.8 22.2S34.1 223.8 41 217l40-40 79 79-79 79-40-40c-6.9-6.9-17.2-8.9-26.2-5.2S0 302.3 0 312L0 456c0 13.3 10.7 24 24 24l144 0c9.7 0 18.5-5.8 22.2-14.8s1.7-19.3-5.2-26.2l-40-40 79-79 79 79-40 40c-6.9 6.9-8.9 17.2-5.2 26.2S270.3 480 280 480l144 0c13.3 0 24-10.7 24-24l0-144c0-9.7-5.8-18.5-14.8-22.2s-19.3-1.7-26.2 5.2l-40 40-79-79 79-79 40 40c6.9 6.9 17.2 8.9 26.2 5.2S448 209.7 448 200l0-144c0-13.3-10.7-24-24-24L280 32c-9.7 0-18.5 5.8-22.2 14.8S256.2 66.1 263 73l40 40-79 79-79-79 40-40c6.9-6.9 8.9-17.2 5.2-26.2S177.7 32 168 32z"/>
+    const expandIcon = `
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"/>
         </svg>
     `;
     const closeIcon = `
@@ -16,10 +17,17 @@
         </svg>
     `;
 
+    const makeCursorSvg = (plus) => {
+        const sign = plus
+            ? `<line x1='20' y1='13' x2='20' y2='27' stroke-width='3'/><line x1='13' y1='20' x2='27' y2='20' stroke-width='3'/>`
+            : `<line x1='13' y1='20' x2='27' y2='20' stroke-width='3'/>`;
+        const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48' fill='none' stroke='%23888' stroke-linecap='round' stroke-linejoin='round'><circle cx='20' cy='20' r='13' stroke-width='3'/><line x1='30' y1='30' x2='42' y2='42' stroke-width='3'/>${sign}</svg>`;
+        return `url("data:image/svg+xml,${svg}") 20 20, auto`;
+    };
+    const zoomInCursor = makeCursorSvg(true);
+    const zoomOutCursor = makeCursorSvg(false);
+
     // Determine whether the current theme is light or dark.
-    // The HTML element carries the resolved theme name as a class (e.g. "navy", "light").
-    // For the auto/default_theme case, mdbook resolves it to the actual theme name before
-    // setting the class, so we only need to check against the known dark theme names.
     const classList = document.getElementsByTagName('html')[0].classList;
 
     let lastThemeWasLight = true;
@@ -36,6 +44,24 @@
     // --- Expand / modal functionality ---
 
     let modal = null;
+    let zoomLevel = 1;
+    let baseWidth = 0;
+    let baseHeight = 0;
+    const ZOOM_STEP = 0.25;
+    const ZOOM_MIN = 0.5;
+    const ZOOM_MAX = 5;
+
+    const resetZoom = () => {
+        if (!modal) return;
+        zoomLevel = 1;
+        const content = modal.querySelector('.mermaid-modal__content');
+        const wrapper = content?.querySelector('.mermaid-modal__svg-wrapper');
+        if (!wrapper || !baseWidth) return;
+        wrapper.style.width = baseWidth + 'px';
+        wrapper.style.height = baseHeight + 'px';
+        content.scrollLeft = 0;
+        content.scrollTop = 0;
+    };
 
     const closeMermaidModal = () => {
         if (!modal) return;
@@ -51,18 +77,33 @@
         const sourceSvg = sourcePre.querySelector('svg');
         if (!sourceSvg) return;
 
+        zoomLevel = 1;
         content.innerHTML = '';
+        content.scrollTop = 0;
+        content.scrollLeft = 0;
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'mermaid-modal__svg-wrapper';
         const clone = sourceSvg.cloneNode(true);
         clone.style.width = '100%';
         clone.style.height = 'auto';
         clone.style.maxWidth = 'none';
-        content.appendChild(clone);
+        wrapper.appendChild(clone);
+        content.appendChild(wrapper);
+
+        content.style.cursor = zoomInCursor;
 
         const heading = sourcePre.previousElementSibling;
         title.textContent = heading?.textContent?.trim() || 'Diagram';
 
         modal.hidden = false;
         document.body.classList.add('mermaid-modal-open');
+
+        // Capture intrinsic dimensions after layout, before any zoom
+        requestAnimationFrame(() => {
+            baseWidth = clone.getBoundingClientRect().width;
+            baseHeight = clone.getBoundingClientRect().height;
+        });
     };
 
     const createMermaidModal = () => {
@@ -92,16 +133,70 @@
             }
         });
 
+        const content = el.querySelector('.mermaid-modal__content');
+        content.addEventListener('click', (event) => {
+            const wrapper = content.querySelector('.mermaid-modal__svg-wrapper');
+            if (!wrapper || !baseWidth) return;
+
+            // Click position in viewport-relative coords
+            const rect = content.getBoundingClientRect();
+            const viewX = event.clientX - rect.left;
+            const viewY = event.clientY - rect.top;
+
+            // Click position in unscaled SVG coords
+            const svgX = (content.scrollLeft + viewX) / zoomLevel;
+            const svgY = (content.scrollTop + viewY) / zoomLevel;
+
+            // Update zoom
+            if (event.shiftKey) {
+                zoomLevel = Math.max(ZOOM_MIN, zoomLevel - ZOOM_STEP);
+            } else {
+                zoomLevel = Math.min(ZOOM_MAX, zoomLevel + ZOOM_STEP);
+            }
+
+            // Apply zoom by resizing the wrapper. The SVG inside has
+            // width:100% so it scales naturally — no CSS transform needed.
+            wrapper.style.width = (baseWidth * zoomLevel) + 'px';
+            wrapper.style.height = (baseHeight * zoomLevel) + 'px';
+
+            // Force synchronous reflow so the scroll container knows its
+            // new scrollable extents before we set scroll position.
+            void content.scrollWidth;
+
+            content.scrollLeft = svgX * zoomLevel - rect.width / 2;
+            content.scrollTop = svgY * zoomLevel - rect.height / 2;
+        });
+
         document.body.appendChild(el);
         return el;
     };
 
     document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') closeMermaidModal();
+        if (!modal || modal.hidden) return;
+        if (event.key === 'Escape') {
+            if (Math.abs(zoomLevel - 1) > 0.01) {
+                resetZoom();
+                event.preventDefault();
+            } else {
+                closeMermaidModal();
+            }
+            return;
+        }
+        if (event.key === 'Shift') {
+            const content = modal.querySelector('.mermaid-modal__content');
+            if (content) content.style.cursor = zoomOutCursor;
+        }
+    });
+
+    document.addEventListener('keyup', (event) => {
+        if (!modal || modal.hidden) return;
+        if (event.key === 'Shift') {
+            const content = modal.querySelector('.mermaid-modal__content');
+            if (content) content.style.cursor = zoomInCursor;
+        }
     });
 
     // Add expand buttons to rendered mermaid diagrams.
-    // Mermaid renders asynchronously after startOnLoad, so we wait for SVGs to appear.
     const enhanceMermaidDiagrams = () => {
         for (const diagram of document.querySelectorAll('pre.mermaid')) {
             if (!diagram.querySelector('svg')) continue;
@@ -111,7 +206,7 @@
             expandButton.type = 'button';
             expandButton.className = 'mermaid-expand-button';
             expandButton.setAttribute('aria-label', 'Expand diagram');
-            expandButton.innerHTML = maximizeIcon;
+            expandButton.innerHTML = expandIcon;
             expandButton.addEventListener('click', (event) => {
                 event.stopPropagation();
                 openMermaidModal(diagram);
@@ -121,8 +216,6 @@
         }
     };
 
-    // Add expand buttons once mermaid has rendered SVGs into pre.mermaid elements.
-    // Use a MutationObserver to handle diagrams that render asynchronously.
     const enhance = () => enhanceMermaidDiagrams();
     const observer = new MutationObserver(enhance);
 
@@ -136,10 +229,7 @@
         observer.observe(document.body, { childList: true, subtree: true });
     }
 
-    // Simplest way to make mermaid re-render the diagrams in the new theme is via refreshing the page.
-    // Only reload when the theme actually changes between light and dark categories.
-    // For the "Auto" button (id="mdbook-theme-default_theme"), we resolve via prefers-color-scheme.
-
+    // Reload page on theme change between light/dark to re-render mermaid diagrams.
     const isLightTheme = (themeId) => {
         if (themeId === 'default_theme') {
             return !window.matchMedia('(prefers-color-scheme: dark)').matches;

--- a/src/bin/assets/mermaid-init.js
+++ b/src/bin/assets/mermaid-init.js
@@ -4,8 +4,22 @@
 
 (() => {
     const darkThemes = ['ayu', 'navy', 'coal'];
-    const lightThemes = ['light', 'rust'];
+    const mermaidModalId = 'mermaid-diagram-modal';
+    const maximizeIcon = `
+        <svg viewBox="0 0 448 512" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M168 32L24 32C10.7 32 0 42.7 0 56L0 200c0 9.7 5.8 18.5 14.8 22.2S34.1 223.8 41 217l40-40 79 79-79 79-40-40c-6.9-6.9-17.2-8.9-26.2-5.2S0 302.3 0 312L0 456c0 13.3 10.7 24 24 24l144 0c9.7 0 18.5-5.8 22.2-14.8s1.7-19.3-5.2-26.2l-40-40 79-79 79 79-40 40c-6.9 6.9-8.9 17.2-5.2 26.2S270.3 480 280 480l144 0c13.3 0 24-10.7 24-24l0-144c0-9.7-5.8-18.5-14.8-22.2s-19.3-1.7-26.2 5.2l-40 40-79-79 79-79 40 40c6.9 6.9 17.2 8.9 26.2 5.2S448 209.7 448 200l0-144c0-13.3-10.7-24-24-24L280 32c-9.7 0-18.5 5.8-22.2 14.8S256.2 66.1 263 73l40 40-79 79-79-79 40-40c6.9-6.9 8.9-17.2 5.2-26.2S177.7 32 168 32z"/>
+        </svg>
+    `;
+    const closeIcon = `
+        <svg viewBox="0 0 384 512" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"/>
+        </svg>
+    `;
 
+    // Determine whether the current theme is light or dark.
+    // The HTML element carries the resolved theme name as a class (e.g. "navy", "light").
+    // For the auto/default_theme case, mdbook resolves it to the actual theme name before
+    // setting the class, so we only need to check against the known dark theme names.
     const classList = document.getElementsByTagName('html')[0].classList;
 
     let lastThemeWasLight = true;
@@ -19,21 +33,130 @@
     const theme = lastThemeWasLight ? 'default' : 'dark';
     mermaid.initialize({ startOnLoad: true, theme });
 
-    // Simplest way to make mermaid re-render the diagrams in the new theme is via refreshing the page
+    // --- Expand / modal functionality ---
 
-    for (const darkTheme of darkThemes) {
-        document.getElementById('mdbook-theme-' + darkTheme).addEventListener('click', () => {
-            if (lastThemeWasLight) {
-                window.location.reload();
+    let modal = null;
+
+    const closeMermaidModal = () => {
+        if (!modal) return;
+        modal.hidden = true;
+        document.body.classList.remove('mermaid-modal-open');
+    };
+
+    const openMermaidModal = (sourcePre) => {
+        if (!modal) modal = createMermaidModal();
+
+        const content = modal.querySelector('.mermaid-modal__content');
+        const title = modal.querySelector('.mermaid-modal__title');
+        const sourceSvg = sourcePre.querySelector('svg');
+        if (!sourceSvg) return;
+
+        content.innerHTML = '';
+        const clone = sourceSvg.cloneNode(true);
+        clone.style.width = '100%';
+        clone.style.height = 'auto';
+        clone.style.maxWidth = 'none';
+        content.appendChild(clone);
+
+        const heading = sourcePre.previousElementSibling;
+        title.textContent = heading?.textContent?.trim() || 'Diagram';
+
+        modal.hidden = false;
+        document.body.classList.add('mermaid-modal-open');
+    };
+
+    const createMermaidModal = () => {
+        const el = document.createElement('div');
+        el.id = mermaidModalId;
+        el.className = 'mermaid-modal';
+        el.hidden = true;
+        el.innerHTML = `
+            <div class="mermaid-modal__backdrop"></div>
+            <div class="mermaid-modal__panel" role="dialog" aria-modal="true" aria-labelledby="${mermaidModalId}-title">
+                <div class="mermaid-modal__header">
+                    <strong id="${mermaidModalId}-title" class="mermaid-modal__title">Diagram</strong>
+                    <button type="button" class="mermaid-modal__close" aria-label="Close expanded diagram">${closeIcon}</button>
+                </div>
+                <div class="mermaid-modal__content"></div>
+            </div>
+        `;
+
+        el.addEventListener('click', (event) => {
+            if (event.target.closest && event.target.closest('.mermaid-modal__close')) {
+                closeMermaidModal();
+                return;
+            }
+            const panel = el.querySelector('.mermaid-modal__panel');
+            if (panel && !panel.contains(event.target)) {
+                closeMermaidModal();
             }
         });
+
+        document.body.appendChild(el);
+        return el;
+    };
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') closeMermaidModal();
+    });
+
+    // Add expand buttons to rendered mermaid diagrams.
+    // Mermaid renders asynchronously after startOnLoad, so we wait for SVGs to appear.
+    const enhanceMermaidDiagrams = () => {
+        for (const diagram of document.querySelectorAll('pre.mermaid')) {
+            if (!diagram.querySelector('svg')) continue;
+            if (diagram.querySelector('.mermaid-expand-button')) continue;
+
+            const expandButton = document.createElement('button');
+            expandButton.type = 'button';
+            expandButton.className = 'mermaid-expand-button';
+            expandButton.setAttribute('aria-label', 'Expand diagram');
+            expandButton.innerHTML = maximizeIcon;
+            expandButton.addEventListener('click', (event) => {
+                event.stopPropagation();
+                openMermaidModal(diagram);
+            });
+
+            diagram.appendChild(expandButton);
+        }
+    };
+
+    // Add expand buttons once mermaid has rendered SVGs into pre.mermaid elements.
+    // Use a MutationObserver to handle diagrams that render asynchronously.
+    const enhance = () => enhanceMermaidDiagrams();
+    const observer = new MutationObserver(enhance);
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => {
+            enhance();
+            observer.observe(document.body, { childList: true, subtree: true });
+        }, { once: true });
+    } else {
+        enhance();
+        observer.observe(document.body, { childList: true, subtree: true });
     }
 
-    for (const lightTheme of lightThemes) {
-        document.getElementById('mdbook-theme-' + lightTheme).addEventListener('click', () => {
-            if (!lastThemeWasLight) {
-                window.location.reload();
-            }
-        });
+    // Simplest way to make mermaid re-render the diagrams in the new theme is via refreshing the page.
+    // Only reload when the theme actually changes between light and dark categories.
+    // For the "Auto" button (id="mdbook-theme-default_theme"), we resolve via prefers-color-scheme.
+
+    const isLightTheme = (themeId) => {
+        if (themeId === 'default_theme') {
+            return !window.matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+        return !darkThemes.includes(themeId);
+    };
+
+    const themeList = document.getElementById('mdbook-theme-list');
+    if (themeList) {
+        for (const button of themeList.querySelectorAll('button.theme')) {
+            button.addEventListener('click', () => {
+                const themeId = button.id.replace('mdbook-theme-', '');
+                const newIsLight = isLightTheme(themeId);
+                if (newIsLight !== lastThemeWasLight) {
+                    window.location.reload();
+                }
+            });
+        }
     }
 })();

--- a/src/bin/assets/mermaid-modal.css
+++ b/src/bin/assets/mermaid-modal.css
@@ -46,8 +46,8 @@ pre.mermaid:hover .mermaid-expand-button,
 }
 
 .mermaid-expand-button svg {
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
 }
 
 /* Modal overlay */
@@ -134,4 +134,9 @@ pre.mermaid:hover .mermaid-expand-button,
     width: 100%;
     height: auto;
     max-width: none;
+}
+
+.mermaid-modal__svg-wrapper {
+    display: inline-block;
+    min-width: 100%;
 }

--- a/src/bin/assets/mermaid-modal.css
+++ b/src/bin/assets/mermaid-modal.css
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* Ensure the mermaid pre block is a positioning context for the expand button */
+.content pre.mermaid {
+    position: relative;
+}
+
+.content pre.mermaid svg {
+    display: block;
+    margin: 0 auto;
+}
+
+/* Expand button (upper-right corner of each diagram) */
+.mermaid-expand-button {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--icons);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--icons);
+    cursor: pointer;
+    padding: 0;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s, border-color 0.15s;
+    z-index: 1;
+}
+
+pre.mermaid:hover .mermaid-expand-button,
+.mermaid-expand-button:focus-visible {
+    opacity: 1;
+}
+
+.mermaid-expand-button:hover,
+.mermaid-expand-button:focus-visible {
+    background: var(--sidebar-bg);
+    border-color: var(--sidebar-active);
+    color: var(--sidebar-active);
+}
+
+.mermaid-expand-button svg {
+    width: 14px;
+    height: 14px;
+}
+
+/* Modal overlay */
+.mermaid-modal-open {
+    overflow: hidden;
+}
+
+.mermaid-modal[hidden] {
+    display: none;
+}
+
+.mermaid-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+}
+
+.mermaid-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+}
+
+.mermaid-modal__panel {
+    position: relative;
+    margin: min(4vh, 24px) auto;
+    width: min(96vw, 1600px);
+    max-height: 92vh;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--icons);
+    background: var(--bg);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+}
+
+.mermaid-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--icons);
+}
+
+.mermaid-modal__title {
+    color: var(--fg);
+    font-size: 1rem;
+}
+
+.mermaid-modal__close {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--icons);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--icons);
+    cursor: pointer;
+    padding: 0;
+}
+
+.mermaid-modal__close:hover,
+.mermaid-modal__close:focus-visible {
+    background: var(--sidebar-bg);
+    border-color: var(--sidebar-active);
+    color: var(--sidebar-active);
+}
+
+.mermaid-modal__close svg {
+    width: 14px;
+    height: 14px;
+}
+
+.mermaid-modal__content {
+    overflow: auto;
+    padding: 20px;
+    flex: 1;
+}
+
+.mermaid-modal__content svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: none;
+}

--- a/src/bin/mdbook-mermaid.rs
+++ b/src/bin/mdbook-mermaid.rs
@@ -13,9 +13,11 @@ use std::{
 
 const MERMAID_JS: &[u8] = include_bytes!("assets/mermaid.min.js");
 const MERMAID_INIT_JS: &[u8] = include_bytes!("assets/mermaid-init.js");
+const MERMAID_MODAL_CSS: &[u8] = include_bytes!("assets/mermaid-modal.css");
 const MERMAID_FILES: &[(&str, &[u8])] = &[
     ("mermaid.min.js", MERMAID_JS),
     ("mermaid-init.js", MERMAID_INIT_JS),
+    ("mermaid-modal.css", MERMAID_MODAL_CSS),
 ];
 
 pub fn make_app() -> Command {
@@ -178,10 +180,24 @@ fn add_additional_files(doc: &mut Document) -> bool {
         log::debug!("'{}' already in 'additional-js'. Skipping", file)
     } else {
         if !printed {
+            printed = true;
             log::info!("Adding additional files to configuration");
         }
         log::debug!("Adding '{}' to 'additional-js'", file);
         insert_additional(doc, "js", file);
+        changed = true;
+    }
+
+    let file = "mermaid-modal.css";
+    let additional_css = additional(doc, "css");
+    if has_file(&additional_css, file) {
+        log::debug!("'{}' already in 'additional-css'. Skipping", file)
+    } else {
+        if !printed {
+            log::info!("Adding additional files to configuration");
+        }
+        log::debug!("Adding '{}' to 'additional-css'", file);
+        insert_additional(doc, "css", file);
         changed = true;
     }
 

--- a/tests/it/empty.toml.output
+++ b/tests/it/empty.toml.output
@@ -10,3 +10,4 @@ command = "mdbook-mermaid"
 
 [output.html]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-css = ["mermaid-modal.css"]

--- a/tests/it/full.toml
+++ b/tests/it/full.toml
@@ -7,3 +7,4 @@ renderer = ["html"]
 
 [output.html]
 additional-js =["mermaid.min.js", "mermaid-init.js"]
+additional-css = ["mermaid-modal.css"]

--- a/tests/it/full.toml.output
+++ b/tests/it/full.toml.output
@@ -7,3 +7,4 @@ renderer = ["html"]
 
 [output.html]
 additional-js =["mermaid.min.js", "mermaid-init.js"]
+additional-css = ["mermaid-modal.css"]

--- a/tests/it/install.rs
+++ b/tests/it/install.rs
@@ -37,7 +37,11 @@ macro_rules! test_install {
         );
         assert!(
             tmp.path().join("mermaid-init.js").exists(),
-            "Failed to copy mermaid.min.js"
+            "Failed to copy mermaid-init.js"
+        );
+        assert!(
+            tmp.path().join("mermaid-modal.css").exists(),
+            "Failed to copy mermaid-modal.css"
         );
     };
 }

--- a/tests/it/missing-js.toml.output
+++ b/tests/it/missing-js.toml.output
@@ -8,3 +8,4 @@ command = "mdbook-mermaid"
 
 [output.html]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-css = ["mermaid-modal.css"]

--- a/tests/it/some.toml.output
+++ b/tests/it/some.toml.output
@@ -8,3 +8,4 @@ command = "mdbook-mermaid"
 
 [output.html]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-css = ["mermaid-modal.css"]


### PR DESCRIPTION
Add an expand icon to the upper-right corner of rendered mermaid diagrams
that opens a full-viewport modal for better readability of complex diagrams.
The modal includes a title bar (derived from the preceding heading), a close
button (X icon), backdrop click-to-close, and Escape key support.

Styles use mdBook CSS custom properties (`--bg`, `--fg`, `--icons` , etc.) so the
feature works across all built-in themes including Auto. Theme switching is
updated to handle the Auto/default_theme case via prefers-color-scheme.

- add mermaid-modal.css for theme-agnostic styles for expand button and modal
- updated mermaid-init.js to add modal logic and improved theme switch handling
- updated mdbook-mermaid.rs to bundle and install mermaid-modal.css as additional-css
- add test fixtures for new CSS asset
- add interactive zoom for expanded diagrams
  - add zoom in/out custom icons
  - add click to zoom in and shift-click to zoom out
    - if zoomed in either direction, ESC now resets the zoom
    - ESC still closes modal once zoom level is 100%